### PR TITLE
Fixed big-endian bug

### DIFF
--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -288,6 +288,21 @@ def test_save_unsupported_mode(tmp_path):
 
 @pytest.mark.parametrize(
     ("mode", "test_file"),
+    (
+        ("L", "Tests/images/l.dds"),
+        ("LA", "Tests/images/la.dds"),
+        ("RGB", "Tests/images/rgb.dds"),
+        ("RGBA", "Tests/images/rgba.dds"),
+    ),
+)
+def test_open(mode, test_file):
+    with Image.open(test_file) as im:
+        assert im.mode == mode
+        assert_image_equal_tofile(im, test_file.replace(".dds", ".png"))
+
+
+@pytest.mark.parametrize(
+    ("mode", "test_file"),
     [
         ("L", "Tests/images/l.png"),
         ("LA", "Tests/images/la.png"),
@@ -303,19 +318,3 @@ def test_save(mode, test_file, tmp_path):
 
         with Image.open(out) as reloaded:
             assert_image_equal(im, reloaded)
-
-
-@pytest.mark.parametrize(
-    ("mode", "expected_file", "input_file"),
-    [
-        ("L", "Tests/images/l.png", "Tests/images/l.dds"),
-        ("LA", "Tests/images/la.png", "Tests/images/la.dds"),
-        ("RGB", "Tests/images/rgb.png", "Tests/images/rgb.dds"),
-        ("RGBA", "Tests/images/rgba.png", "Tests/images/rgba.dds"),
-    ],
-)
-def test_open(mode, expected_file, input_file):
-    with Image.open(input_file) as im:
-        assert im.mode == mode
-        with Image.open(expected_file) as im2:
-            assert_image_equal(im, im2)

--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -277,7 +277,6 @@ class DdsImageFile(ImageFile.ImageFile):
     format = "DDS"
     format_description = "DirectDraw Surface"
 
-    # fmt: off
     def _open(self):
         if not _accept(self.fp.read(4)):
             raise SyntaxError("not a DDS file")
@@ -313,10 +312,12 @@ class DdsImageFile(ImageFile.ImageFile):
                 self.tile = [("raw", extents, 0, (rawmode[::-1], 0, 1))]
             elif bitcount == 32 and pfflags & DDPF.ALPHAPIXELS:
                 self.mode = "RGBA"
-                rawmode = (masks[0xFF000000] +
-                           masks[0x00FF0000] +
-                           masks[0x0000FF00] +
-                           masks[0x000000FF])
+                rawmode = (
+                    masks[0xFF000000]
+                    + masks[0x00FF0000]
+                    + masks[0x0000FF00]
+                    + masks[0x000000FF]
+                )
                 self.tile = [("raw", extents, 0, (rawmode[::-1], 0, 1))]
             else:
                 raise OSError(f"Unsupported bitcount {bitcount} for {pfflags}")
@@ -398,15 +399,12 @@ class DdsImageFile(ImageFile.ImageFile):
         else:
             raise NotImplementedError(f"Unknown pixel format flags {repr(pfflags)}")
 
-    # fmt: on
-
     def load_seek(self, pos):
         pass
 
 
-# fmt: off
 def _save(im, fp, filename):
-    if im.mode not in ("RGB", "RGBA", "L", 'LA'):
+    if im.mode not in ("RGB", "RGBA", "L", "LA"):
         raise OSError(f"cannot write mode {im.mode} as DDS")
 
     pixel_flags = DDPF.RGB
@@ -419,7 +417,7 @@ def _save(im, fp, filename):
         bit_count = 32
         r, g, b, a = im.split()
         im = Image.merge("RGBA", (a, r, g, b))
-    elif im.mode == 'LA':
+    elif im.mode == "LA":
         pixel_flags = DDPF.LUMINANCE | DDPF.ALPHAPIXELS
         rgba_mask = struct.pack("<4I", 0x000000FF, 0x000000FF, 0x000000FF, 0x0000FF00)
         bit_count = 16
@@ -433,8 +431,16 @@ def _save(im, fp, filename):
     stride = (im.width * bit_count + 7) // 8
     fp.write(
         o32(DDS_MAGIC)
-        # header size, flags, height, width, pitch, depth, mipmaps
-        + struct.pack("<IIIIIII", 124, flags, im.height, im.width, stride, 0, 0, )
+        + struct.pack(
+            "<IIIIIII",
+            124,  # header size
+            flags,  # flags
+            im.height,
+            im.width,
+            stride,  # pitch
+            0,  # depth
+            0,  # mipmaps
+        )
         + struct.pack("11I", *((0,) * 11))  # reserved
         # pfsize, pfflags, fourcc, bitcount
         + struct.pack("<IIII", 32, pixel_flags, 0, bit_count)
@@ -443,9 +449,6 @@ def _save(im, fp, filename):
     )
     mode = "LA" if im.mode == "LA" else im.mode[::-1]
     ImageFile._save(im, fp, [Image.Tile("raw", (0, 0) + im.size, 0, (mode, 0, 1))])
-
-
-# fmt: on
 
 
 def _accept(prefix):

--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -15,6 +15,7 @@ from enum import IntEnum, IntFlag
 from io import BytesIO
 
 from . import Image, ImageFile
+from ._binary import i32le as i32
 from ._binary import o32le as o32
 
 # Magic ("DDS ")
@@ -191,10 +192,6 @@ class DXGI_FORMAT(IntEnum):
         return cls.INVALID
 
 
-def make_fourcc(name):
-    return struct.unpack("I", name.encode("ascii"))[0]
-
-
 class D3DFMT(IntEnum):
     UNKNOWN = 0
     R8G8B8 = 20
@@ -252,20 +249,20 @@ class D3DFMT(IntEnum):
     A2B10G10R10_XR_BIAS = 119
     BINARYBUFFER = 199
 
-    UYVY = make_fourcc("UYVY")
-    R8G8_B8G8 = make_fourcc("RGBG")
-    YUY2 = make_fourcc("YUY2")
-    G8R8_G8B8 = make_fourcc("GRGB")
-    DXT1 = make_fourcc("DXT1")
-    DXT2 = make_fourcc("DXT2")
-    DXT3 = make_fourcc("DXT3")
-    DXT4 = make_fourcc("DXT4")
-    DXT5 = make_fourcc("DXT5")
-    DX10 = make_fourcc("DX10")
-    BC5S = make_fourcc("BC5S")
-    ATI1 = make_fourcc("ATI1")
-    ATI2 = make_fourcc("ATI2")
-    MULTI2_ARGB8 = make_fourcc("MET1")
+    UYVY = i32(b"UYVY")
+    R8G8_B8G8 = i32(b"RGBG")
+    YUY2 = i32(b"YUY2")
+    G8R8_G8B8 = i32(b"GRGB")
+    DXT1 = i32(b"DXT1")
+    DXT2 = i32(b"DXT2")
+    DXT3 = i32(b"DXT3")
+    DXT4 = i32(b"DXT4")
+    DXT5 = i32(b"DXT5")
+    DX10 = i32(b"DX10")
+    BC5S = i32(b"BC5S")
+    ATI1 = i32(b"ATI1")
+    ATI2 = i32(b"ATI2")
+    MULTI2_ARGB8 = i32(b"MET1")
     INVALID = -1
 
     @classmethod

--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -433,7 +433,7 @@ def _save(im, fp, filename):
     stride = (im.width * bit_count + 7) // 8
     fp.write(
         o32(DDS_MAGIC)
-        # header size, flags, height, width, pith, depth, mipmaps
+        # header size, flags, height, width, pitch, depth, mipmaps
         + struct.pack("<IIIIIII", 124, flags, im.height, im.width, stride, 0, 0, )
         + struct.pack("11I", *((0,) * 11))  # reserved
         # pfsize, pfflags, fourcc, bitcount

--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -12,7 +12,6 @@ Full text of the CC0 license:
 import io
 import struct
 from enum import IntEnum, IntFlag
-from io import BytesIO
 
 from . import Image, ImageFile
 from ._binary import i32le as i32
@@ -283,7 +282,7 @@ class DdsImageFile(ImageFile.ImageFile):
         header_bytes = self.fp.read(header_size - 4)
         if len(header_bytes) != 120:
             raise OSError(f"Incomplete header: {len(header_bytes)} bytes")
-        header = BytesIO(header_bytes)
+        header = io.BytesIO(header_bytes)
 
         flags_, height, width = struct.unpack("<3I", header.read(12))
         flags = DDSD(flags_)


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/6486

- Simplified test code
- Fixed typo
- Removed '# fmt: off' and '# fmt: on' lines. I don't think the formatting looks that bad?
- In our s390x CI at the moment, [your PR is failing](https://github.com/python-pillow/Pillow/actions/runs/2936308815/jobs/5012691033#step:6:410). This is because `make_fourcc` doesn't specify the endianness. I've replaced it with [`i32`](https://github.com/python-pillow/Pillow/blob/243402e78e2bf2b7af478c6d891816e372b5c3f9/src/PIL/_binary.py#L60-L67), and the tests pass.
- Simplified imports